### PR TITLE
whitelist libvpx.so

### DIFF
--- a/src/intercept/main.c
+++ b/src/intercept/main.c
@@ -59,6 +59,7 @@ static const char *steam_allowed[] = {
         "libavutil.so.",
         "libswscale.so.",
         "libx264.so.",
+        "libvpx.so.",
 
         /* core plugins */
         "chromehtml.so",


### PR DESCRIPTION
Resolves issue with latest steam beta which crashes with error:
Failed to load steamui.so - dlerror(): libvpx.so.6: cannot open shared object file: No such file or directory

