### PR TITLE
Don't preload libs when native runtime is disabled

### DIFF
--- a/src/shim/shim.c
+++ b/src/shim/shim.c
@@ -312,10 +312,6 @@ bool shim_bootstrap()
                 }
 #endif
         } else {
-                /* Only preload when needed. */
-                if (lsi_system_requires_preload()) {
-                        shim_export_merge_vars("LD_PRELOAD", operation_prefix, lsi_preload_list());
-                }
                 setenv("STEAM_RUNTIME", "1", 1);
         }
 


### PR DESCRIPTION
Made for [T10265](https://dev.getsol.us/T10265) but that problem seems to lie elsewhere, but it does completely fix the overlay [T7754](https://dev.getsol.us/T7754) .
In my testing it didn't cause any issues, it hope it won't cause any problems for anyone else too.