### PR TITLE
Allow SDL3 lib until it's available in repositories

### DIFF
--- a/src/intercept/main.c
+++ b/src/intercept/main.c
@@ -104,6 +104,9 @@ static const char *steam_allowed[] = {
         /* widevine */
         "libwidevinecdmadapter.so",
         "libwidevinecdm.so",
+
+        /* temporary SDL3 fix */
+        "libSDL3.so",
 };
 
 static const char *wanted_steam_processes[] = {


### PR DESCRIPTION
Recent Steam beta versions have started relying on the SDL3 library, leading to an error on launch with LSI enabled. So for now we have to whitelist it, until it gets a proper release and is available as a system/native library.