### PR TITLE
Use steam runtime by default

### DIFF
--- a/src/lsi/lsi.c
+++ b/src/lsi/lsi.c
@@ -201,7 +201,7 @@ void lsi_config_load_defaults(LsiConfig *config)
         /* Very simple right now, but in future we'll expand the options and
          * things that LSI knows about */
         config->force_32 = false;
-        config->use_native_runtime = true;
+        config->use_native_runtime = false;
         config->use_libintercept = true;
         config->use_libredirect = true;
         config->use_unity_hack = true;


### PR DESCRIPTION
#### Problem
LSI has had many issues preventing games from launching over the years, requiring constant patching, especially with critical breakages to the Steam client. This leads to a bad first impression with users encountering issues they do not have anywhere else. I was reminded of this recently by this post: https://discuss.getsol.us/d/9741-cant-use-garrys-mod

#### Proposal
We should stop forcing the use of native runtime by default. This change will not affect existing LSI installs and still allow the use of native runtime should people see a benefit in doing so.